### PR TITLE
Fixed bug in LCD display

### DIFF
--- a/ArcadeHacker_CPS1.ino
+++ b/ArcadeHacker_CPS1.ino
@@ -222,9 +222,13 @@ void loop()   /*----( LOOP: RUNS CONSTANTLY )----*/
       }
     case btnUP:
       {
-     if (c != 0) {c--;}
-     lcd.print(GameList[c]);
-        break;
+       if (c !=0)
+        {
+          if (c > 0) {c--;} else {c++;}
+        }
+      
+       lcd.print(GameList[c]);
+       break;
       }
     case btnDOWN:
       {


### PR DESCRIPTION
Fixed a bug in the where pressing 'UP' first caused garbage to be display on the LCD display.  This was caused by 'c' being set to -2 making Gamelist[c] display garbage.
